### PR TITLE
better conventions

### DIFF
--- a/docs/admin-guide/_category_.json
+++ b/docs/admin-guide/_category_.json
@@ -1,8 +1,0 @@
-{
-  "label": "Admin Guide",
-  "position": 8,
-  "link": {
-    "type": "generated-index",
-    "description": "Admin Guide for basepair account"
-  }
-}

--- a/docs/admin-guide/_category_.yaml
+++ b/docs/admin-guide/_category_.yaml
@@ -1,0 +1,6 @@
+label: Admin Guide
+position: 8
+link:
+  type: generated-index
+  slug: /admin-guide
+  description: Admin Guide for basepair account

--- a/docs/analysis/_category_.json
+++ b/docs/analysis/_category_.json
@@ -1,8 +1,0 @@
-{
-  "label": "Analysis",
-  "position": 3,
-  "link": {
-    "type": "generated-index",
-    "description": "Running a new analysis <GUI/CLI/Python>"
-  }
-}

--- a/docs/analysis/_category_.yaml
+++ b/docs/analysis/_category_.yaml
@@ -1,0 +1,6 @@
+label: Analysis
+position: 3
+link:
+  type: generated-index
+  slug: /analysis
+  description: Running a new analysis <GUI/CLI/Python>

--- a/docs/api-automation/_category_.json
+++ b/docs/api-automation/_category_.json
@@ -1,8 +1,0 @@
-{
-  "label": "API and Automation",
-  "position": 6,
-  "link": {
-    "type": "generated-index",
-    "description": "Setting Up the API"
-  }
-}

--- a/docs/api-automation/_category_.yaml
+++ b/docs/api-automation/_category_.yaml
@@ -1,0 +1,6 @@
+label: API and Automation
+position: 6
+link:
+  type: generated-index
+  slug: /api-automation
+  description: Setting Up the API

--- a/docs/integrations/_category_.json
+++ b/docs/integrations/_category_.json
@@ -1,8 +1,0 @@
-{
-  "label": "Integrations",
-  "position": 7,
-  "link": {
-    "type": "generated-index",
-    "description": "Integrations available on Basepair"
-  }
-}

--- a/docs/integrations/_category_.yaml
+++ b/docs/integrations/_category_.yaml
@@ -2,4 +2,5 @@ label: Integrations
 position: 7
 link:
   type: generated-index
+  slug: /integrations
   description: Integrations available on Basepair

--- a/docs/integrations/_category_.yaml
+++ b/docs/integrations/_category_.yaml
@@ -1,0 +1,5 @@
+label: Integrations
+position: 7
+link:
+  type: generated-index
+  description: Integrations available on Basepair

--- a/docs/integrations/aws.md
+++ b/docs/integrations/aws.md
@@ -1,8 +1,10 @@
 ---
+title: AWS
 sidebar_position: 1
+description: Connected cloud - use your cloud account for storage and compute
 ---
 
-# AWS
+# Connected Cloud - AWS integration
 
 - Connected Cloud is a solution that allows you to run NSG workflows on Basepair platform with your own AWS account.
 - Customer will interact with Basepair platform to upload samples and start workflows.

--- a/docs/pipelines/_category_.json
+++ b/docs/pipelines/_category_.json
@@ -1,8 +1,0 @@
-{
-  "label": "Pipelines",
-  "position": 3,
-  "link": {
-    "type": "generated-index",
-    "description": "how basepair has standard pipelines"
-  }
-}

--- a/docs/pipelines/_category_.yaml
+++ b/docs/pipelines/_category_.yaml
@@ -1,0 +1,6 @@
+label: Pipelines
+position: 3
+link:
+  type: generated-index
+  slug: /pipelines
+  description: how basepair has standard pipelines

--- a/docs/samples/_category_.json
+++ b/docs/samples/_category_.json
@@ -1,8 +1,0 @@
-{
-  "label": "Samples",
-  "position": 2,
-  "link": {
-    "type": "generated-index",
-    "description": "Have tabs with each option GUI/Python/CLI"
-  }
-}

--- a/docs/samples/_category_.yaml
+++ b/docs/samples/_category_.yaml
@@ -1,0 +1,6 @@
+label: Samples
+position: 2
+link:
+  type: generated-index
+  slug: /samples
+  description: Have tabs with each option GUI/Python/CLI


### PR DESCRIPTION
I've made a few changes to use better conventions

1. Use title and description in the top of the markdown page, e.g.

---
title: AWS
sidebar_position: 1
description: Connected cloud - use your cloud account for storage and compute
---

The title is used in the sidebar, so we can keep it brief. Without this, the title of the page is used as the title of the sidebar so we are not able to use a longer title.

The description shows up in the auto generated boxes in the category page.

2. Convert category.json to yaml
Yaml is much easier for humans to edit

3. I couldn't do this - the slug for category page should be cleaner. E.g, currently the path for integrations is http://localhost:3000/category/integrations. It should be just http://localhost:3000/integrations but I was not able to figure out.


Lets add these and other conventions to the README for others to follow a consistent style