### PR TITLE
docs: update API automation docs for v3 migration

### DIFF
--- a/docs/api-automation/automation.md
+++ b/docs/api-automation/automation.md
@@ -8,7 +8,7 @@ With Basepair, you can fully automate an NGS project—create a project, add mul
 
 0. **Sign in** to your Basepair account → `https://{domain}/`
 
-1. **Download your API keys** from `https://{domain}/api/v3/users/api_key/` and save the path of the downloaded file in an environment variable  
+1. **Download your API config** from `https://{domain}/api/v3/users/api_key/` and point to it via an environment variable  
    *(You must be logged in to download the JSON file.)*
 
    ```bash
@@ -24,30 +24,32 @@ With Basepair, you can fully automate an NGS project—create a project, add mul
 3. **Create a new project** for this data (note the returned project ID)
 
    ```bash
-   basepair create project --name desired_project_name
+   basepair project create --name desired_project_name --team <team_id>
    ```
 
 4. **Add your samples** (note each sample ID)
 
    ```bash
-   basepair create sample --name Treat_1   --genome hg19 --datatype rna-seq \
+   basepair sample create --name Treat_1   --genome hg19 --type rna-seq \
      --file1 /path/to/file1_R1.fq.gz --file2 /path/to/file1_R2.fq.gz
 
-   basepair create sample --name Control_1 --genome hg19 --datatype rna-seq \
+   basepair sample create --name Control_1 --genome hg19 --type rna-seq \
      --file1 /path/to/file2_R1.fq.gz --file2 /path/to/file2_R2.fq.gz
 
    # <add all your other samples>
    ```
 
-5. **Run differential-expression analysis** (workflow # 8) using the sample and control IDs from step 4
+5. **Run differential-expression analysis** (pipeline ID 8) using the sample and control IDs from step 4
 
    ```bash
-   basepair create analysis -w 8 --sample 30754 30755 30756 --control 30757 307587 30759
+   basepair analysis create --pipeline 8 \
+     --sample 30754 30755 30756 \
+     --control 30757 30758 30759
    ```
 
 6. **Share the project** with another user (example: give *edit* permission; you can also use *view* or *admin*)
 
    ```bash
-   basepair updateProject -p 1926 --emails amit@basepairtech.com --perm edit
+   basepair project update -u 1926 --team <team_id> \
+     --emails collaborator@example.com --perm edit
    ```
-

--- a/docs/api-automation/automation.md
+++ b/docs/api-automation/automation.md
@@ -8,11 +8,14 @@ With Basepair, you can fully automate an NGS project—create a project, add mul
 
 0. **Sign in** to your Basepair account → `https://{domain}/`
 
-1. **Download your API config** from `https://{domain}/api/v3/users/api_key/` and point to it via an environment variable  
-   *(You must be logged in to download the JSON file.)*
+1. **Download your API config file** — follow the steps in [Setup](./setup#2-configuration) to download it from your dashboard. Then make it available to the CLI using one of:
 
    ```bash
+   # Option A — environment variable (persists for the session)
    export BP_CONFIG_FILE=/path/to/basepair.config.json
+
+   # Option B — per-command flag
+   basepair -c /path/to/basepair.config.json <subcommand>
    ```
 
 2. **Install the Basepair package**
@@ -24,7 +27,7 @@ With Basepair, you can fully automate an NGS project—create a project, add mul
 3. **Create a new project** for this data (note the returned project ID)
 
    ```bash
-   basepair project create --name desired_project_name --team <team_id>
+   basepair project create --name desired_project_name
    ```
 
 4. **Add your samples** (note each sample ID)

--- a/docs/api-automation/cli.md
+++ b/docs/api-automation/cli.md
@@ -14,6 +14,25 @@ All commands follow the pattern:
 basepair <resource> <action> [options] -c /path/to/basepair.config.json
 ```
 
+### Global options
+
+| Option | Description |
+|--------|-------------|
+| `-c, --config PATH` | Path to config JSON file (or set `BP_CONFIG_FILE`) |
+| `-v, --version VERSION` | API version to use: `v3` (default) or `v2` |
+| `--quiet` | Suppress output |
+| `--verbose` | Enable verbose output |
+| `--scratch DIR` | Working directory for temporary files (default: `.`) |
+
+The `-v` / `--version` flag forces a specific API version for that command. Starting with package 3.x, **v3 is the default** — you only need this flag to explicitly use v2:
+
+```bash
+# Use v2 for a specific command (rarely needed)
+basepair -v v2 analysis list --project 8658 -c /path/to/basepair.config.json
+```
+
+Your config file must contain the corresponding section (`api_v3` for v3, `api` for v2) — see [Setup](./setup).
+
 An outline of the contents on this page:
 
 1. Creating a project

--- a/docs/api-automation/cli.md
+++ b/docs/api-automation/cli.md
@@ -4,51 +4,67 @@ sidebar_position: 2
 
 # Command line API
 
+Updated for basepair version 3.x
 
+Command-line (CLI) bindings for Basepair's API. The CLI is a thin wrapper around the Python bindings, which are more fully-featured. If you can't accomplish something with the CLI, check the [Python API](./python) instead.
 
-Updated for basepair version 2.0.0  
+All commands follow the pattern:
 
-Command-line (CLI) bindings for Basepair’s API. The CLI bindings are just a thin wrapper around the Python bindings, which are more fully-featured. If you can’t do something with the CLI, check the Python API instead.
+```bash
+basepair <resource> <action> [options] -c /path/to/basepair.config.json
+```
 
 An outline of the contents on this page:
 
-1. Creating a project  
-2. Creating a sample  
-3. Running an analysis  
-4. Downloading results  
+1. Creating a project
+2. Creating a sample
+3. Running an analysis
+4. Downloading results
+5. Managing pipelines and modules
+6. Other commands
 
 ---
 
 ## 1. Creating a project
 
-First, list your existing projects. A new Basepair account starts with two projects—one with example data and an empty **Project 1**:
+List your existing projects:
 
 ```bash
 basepair project list -c /path/to/basepair.config.json
 ```
 
 ```text
-id   name          owner        fullname          last updated                visibility
----- ------------  -----------  ----------------  --------------------------  -----------
- 784 Example Data  Amit Sinha   2022-03-11T14:01:19.850152  public
-8611 Project 1     Username     2022-05-15T19:20:06.378477  private
+id     name          owner               last updated
+------ ------------- ------------------- --------------------------
+   784 Example Data  user@example.com    2022-03-11T14:01:19
+  8611 Project 1     user@example.com    2022-05-15T19:20:06
 ```
 
-Now, create a new project:
+Create a new project (requires a team ID, visible in your account settings):
 
 ```bash
-basepair project create --name new_project -c /path/to/basepair.config.json
+basepair project create --name my_project --team 1234 -c /path/to/basepair.config.json
 ```
 
 ```text
 created: project with id 8658
 ```
 
+Share a project with a collaborator:
+
+```bash
+basepair project update -u 8658 --team 1234 \
+  --emails collaborator@example.com --perm view \
+  -c /path/to/basepair.config.json
+```
+
+Permission levels: `view`, `edit`, `admin`.
+
 ---
 
 ## 2. Creating a sample
 
-Create a sample within your new project, specifying the sample name, data type, genome, and file locations:
+Create a sample within your project, specifying the sample name, data type, genome, and file locations:
 
 ```bash
 basepair sample create --project 8658 \
@@ -70,11 +86,13 @@ Creating upload read_2.fastq.gz
 Sample created successfully.
 ```
 
-To see all available data types and other metadata:
+To see all available data types:
 
 ```bash
 basepair sample create -h
 ```
+
+Supported types: `atac-seq`, `chip-seq`, `crispr`, `cutnrun`, `cutntag`, `dna-seq`, `other`, `panel`, `rna-seq`, `scaleBio_scRNA`, `scrna-seq`, `small-rna-seq`, `snap-chip`, `wes`, `wgs`.
 
 To list available genomes:
 
@@ -82,17 +100,29 @@ To list available genomes:
 basepair genome list -c /path/to/basepair.config.json
 ```
 
-You can check the samples in a project with:
+List all samples in a project:
 
 ```bash
 basepair sample list --project 8658 -c /path/to/basepair.config.json
+```
+
+Get details for a specific sample:
+
+```bash
+basepair sample get -u 75042 -c /path/to/basepair.config.json
+```
+
+Update a sample (e.g. change genome or data type):
+
+```bash
+basepair sample update -u 75042 --genome hg38 -c /path/to/basepair.config.json
 ```
 
 ---
 
 ## 3. Running an analysis
 
-Run an analysis—here, ATAC-seq alignment with Bowtie 2—by specifying the project, sample, and pipeline:
+Run an analysis by specifying the project, sample, and pipeline:
 
 ```bash
 basepair analysis create --project 8658 \
@@ -111,17 +141,55 @@ To list all available pipelines:
 basepair pipeline list -c /path/to/basepair.config.json
 ```
 
+Run a differential-expression analysis with multiple samples and controls:
+
+```bash
+basepair analysis create \
+  --sample 75042 75043 75044 \
+  --control 75050 75051 \
+  --pipeline 8 \
+  -c /path/to/basepair.config.json
+```
+
+Override per-node parameters (format: `node_id:argument:value`):
+
+```bash
+basepair analysis create \
+  --sample 75042 \
+  --pipeline 8 \
+  --params deseq2:padj:0.01 deseq2:lfc:1.5 \
+  -c /path/to/basepair.config.json
+```
+
+List analyses in a project:
+
+```bash
+basepair analysis list --project 8658 -c /path/to/basepair.config.json
+```
+
+Restart a completed or failed analysis:
+
+```bash
+basepair analysis reanalyze -u 91182 -c /path/to/basepair.config.json
+```
+
+Stop a running analysis:
+
+```bash
+basepair analysis terminate -u 91182 -c /path/to/basepair.config.json
+```
+
 ---
 
 ## 4. Downloading results
 
-Download the entire analysis directory tree and all files for a given analysis ID:
+Download all files for a given analysis:
 
 ```bash
 basepair analysis download -u 91182 -c /path/to/basepair.config.json
 ```
 
-To download only the alignment BAM and BAM index files (tagged **dedup**) and their directory tree:
+Download only the deduplicated alignment BAM files (tagged **dedup**):
 
 ```bash
 basepair analysis download -u 91182 \
@@ -130,19 +198,93 @@ basepair analysis download -u 91182 \
   -c /path/to/basepair.config.json
 ```
 
+Download only BAM files, saving to a specific directory:
+
+```bash
+basepair analysis download -u 91182 \
+  --tags bam \
+  --tagkind exact \
+  -o ./bams \
+  -c /path/to/basepair.config.json
+```
+
+Download everything except log files:
+
+```bash
+basepair analysis download -u 91182 \
+  --tags log \
+  --tagkind diff \
+  -c /path/to/basepair.config.json
+```
+
+**Tag filter modes:**
+
+| Mode | Behaviour |
+|------|-----------|
+| `exact` | Only files whose tag set exactly matches the provided tags |
+| `subset` | Any file that has at least one of the provided tags |
+| `diff` | Exclude files that have the provided tag |
+
 To list all files of an analysis with their tags:
 
 ```bash
 basepair analysis get -u 91182 -c /path/to/basepair.config.json
 ```
 
-To download only the heatmaps and bigWig track from an analysis:
+Download the execution log:
 
 ```bash
-basepair analysis download -u 90747 \
-  --tags png igv \
-  --tagkind subset \
-  -c /path/to/basepair.config.json
+basepair analysis download-log -u 91182 -o ./logs -c /path/to/basepair.config.json
 ```
 
+---
 
+## 5. Managing pipelines and modules
+
+Create a pipeline from a YAML definition file:
+
+```bash
+basepair pipeline create --file /path/to/pipeline.yaml -c /path/to/basepair.config.json
+```
+
+Update an existing pipeline:
+
+```bash
+basepair pipeline update -u 380 --file /path/to/pipeline.yaml -c /path/to/basepair.config.json
+```
+
+Create a module:
+
+```bash
+basepair module create --file /path/to/module.yaml -c /path/to/basepair.config.json
+```
+
+List modules for a pipeline:
+
+```bash
+basepair module list --pipeline 19 -c /path/to/basepair.config.json
+```
+
+---
+
+## 6. Other commands
+
+**Get JSON output** — add `--json` to any `get` or `list` command:
+
+```bash
+basepair analysis list --project 8658 --json -c /path/to/basepair.config.json
+basepair sample get -u 75042 --json -c /path/to/basepair.config.json
+```
+
+**Download a file by ID:**
+
+```bash
+basepair file download -u 456789 -o ./downloads -c /path/to/basepair.config.json
+```
+
+**Delete resources:**
+
+```bash
+basepair analysis delete -u 91182 -c /path/to/basepair.config.json
+basepair sample delete -u 75042 -c /path/to/basepair.config.json
+```

--- a/docs/api-automation/migration.md
+++ b/docs/api-automation/migration.md
@@ -1,0 +1,116 @@
+---
+sidebar_position: 5
+---
+
+# Migrating from API v2 to v3
+
+This page covers every breaking change introduced in the v3 API and how to update your scripts.
+
+---
+
+## 1. Upgrade the package
+
+```bash
+pip install --upgrade "basepair>=3.1.0"
+```
+
+---
+
+## 2. Update your config file
+
+The config file now uses the key `api_v3` (instead of `api`) and the prefix `/api/v3/`.
+
+**Before (v2):**
+
+```json
+{
+  "api": {
+    "host": "app.basepairtech.com",
+    "prefix": "/api/v2/",
+    "username": "user@example.com",
+    "key": "YOUR_API_KEY"
+  }
+}
+```
+
+**After (v3):**
+
+```json
+{
+  "api_v3": {
+    "host": "app.basepairtech.com",
+    "prefix": "/api/v3/",
+    "ssl": true,
+    "username": "user@example.com",
+    "key": "YOUR_API_KEY"
+  }
+}
+```
+
+You can download a fresh config file from your profile page at [app.basepairtech.com](https://app.basepairtech.com).
+
+---
+
+## 3. Update CLI commands
+
+The command syntax changed in v3. The old `--action` style was replaced with subcommands.
+
+| Task | v2 command | v3 command |
+|------|-----------|-----------|
+| Create sample | `basepair --action create-sample --name S` | `basepair sample create --name S` |
+| List samples | `basepair --action list-samples --project 1` | `basepair sample list --project 1` |
+| Update sample | `basepair --action update-sample -s 123 --key genome --val mm10` | `basepair sample update -u 123 --genome mm10` |
+| Delete sample | `basepair --action delete-sample -s 123` | `basepair sample delete -u 123` |
+| Create analysis | `basepair --action create-analysis -w 10 -s 123` | `basepair analysis create --pipeline 10 --sample 123` |
+| List analyses | `basepair --action list-analyses --project 1` | `basepair analysis list --project 1` |
+| Download results | `basepair --action download -a 456` | `basepair analysis download -u 456` |
+| List projects | `basepair --action list-projects` | `basepair project list` |
+
+The general pattern is:
+
+```
+basepair <resource> <action> [options] -c config.json
+```
+
+---
+
+## 4. Update Python code that reads file data
+
+In v3, file objects return a `uri` field (a full `s3://…` URI). Code that reads `file['path']` will break.
+
+**Before (v2):**
+
+```python
+for f in analysis['files']:
+    s3_key = f['path']   # e.g. "data/results/sample.bam"
+```
+
+**After (v3):**
+
+```python
+for f in analysis['files']:
+    uri = f['uri']       # e.g. "s3://my-bucket/data/results/sample.bam"
+```
+
+If you need the bare S3 key:
+
+```python
+from basepair.modules.storage.drivers.aws_s3 import Driver as S3Driver
+
+s3_key = S3Driver.get_path_from_uri(f['uri'])
+```
+
+---
+
+## 5. Downloads no longer require local AWS credentials
+
+In v3, sample and analysis downloads work via server-generated presigned URLs. You no longer need AWS credentials configured locally to download results. The SDK handles this automatically and falls back to `aws s3 cp` if needed.
+
+---
+
+## Summary checklist
+
+- [ ] `pip install --upgrade "basepair>=3.1.0"`
+- [ ] Replace `api` key with `api_v3` in config; change prefix to `/api/v3/`
+- [ ] Update CLI scripts from `--action` style to `basepair <resource> <action>` style
+- [ ] Replace `file['path']` with `file['uri']` in Python code that processes result files

--- a/docs/api-automation/migration.md
+++ b/docs/api-automation/migration.md
@@ -102,7 +102,34 @@ s3_key = S3Driver.get_path_from_uri(f['uri'])
 
 ---
 
-## 5. Downloads no longer require local AWS credentials
+## 5. Update direct class usage
+
+If you use individual module classes (`Analysis`, `Sample`, `Upload`, etc.) directly rather than through `basepair.connect()`, the config key you pass must match the API version.
+
+**Before (v2 config):**
+
+```python
+config = json.load(open('basepair.config.json'))
+Analysis(config.get('api')).list_all_full(filters={...})
+```
+
+**After (v3 config):**
+
+```python
+config = json.load(open('basepair.config.json'))
+Analysis(config.get('api_v3')).list_all_full(filters={...})
+```
+
+Alternatively, connect via `basepair.connect()` and use `bp.conf.get('api')`, which always holds the resolved config regardless of version:
+
+```python
+bp = basepair.connect(json.load(open('basepair.config.json')))
+Analysis(bp.conf.get('api')).list_all_full(filters={...})
+```
+
+---
+
+## 6. Downloads no longer require local AWS credentials
 
 In v3, sample and analysis downloads work via server-generated presigned URLs. You no longer need AWS credentials configured locally to download results. The SDK handles this automatically and falls back to `aws s3 cp` if needed.
 
@@ -114,3 +141,5 @@ In v3, sample and analysis downloads work via server-generated presigned URLs. Y
 - [ ] Replace `api` key with `api_v3` in config; change prefix to `/api/v3/`
 - [ ] Update CLI scripts from `--action` style to `basepair <resource> <action>` style
 - [ ] Replace `file['path']` with `file['uri']` in Python code that processes result files
+- [ ] Update direct class calls from `config.get('api')` to `config.get('api_v3')` (or use `bp.conf.get('api')`)
+- [ ] Update any code that parses v2 plain-text errors to handle the v3 `errors[].detail` structure

--- a/docs/api-automation/python.md
+++ b/docs/api-automation/python.md
@@ -38,24 +38,10 @@ import json
 bp = basepair.connect(json.load(open('/path/to/basepair.config.json')))
 ```
 
-Starting with package 3.x, **v3 is the default**. To explicitly select a version, pass the `version` argument:
+Alternatively, set `BP_CONFIG_FILE` in your environment and call `connect()` with no arguments:
 
 ```python
-# Explicit v3 (same as default)
-bp = basepair.connect(json.load(open('/path/to/basepair.config.json')), version='v3')
-
-# Explicit v2 (requires an "api" section in your config)
-bp = basepair.connect(json.load(open('/path/to/basepair.config.json')), version='v2')
-```
-
-You can also connect using environment variables without a file:
-
-```python
-import os
-import basepair
-
-os.environ['BP_USERNAME'] = 'user@example.com'
-os.environ['BP_API_KEY'] = 'YOUR_API_KEY'
+# BP_CONFIG_FILE=/path/to/basepair.config.json already exported
 bp = basepair.connect()
 ```
 
@@ -108,6 +94,7 @@ bp.get_samples(filters={'projects': 8658})
 
 ```python
 sample = bp.get_sample(75042)
+print(sample)  # dict with sample fields (id, name, genome, status, …)
 ```
 
 ### 2.5 List analyses
@@ -122,10 +109,17 @@ Raw list:
 bp.get_analyses(filters={'projects': 8658})
 ```
 
-Analysis detail:
+Analysis detail — pretty table:
+
+```python
+bp.print_data('analysis', uid=[91182])
+```
+
+Raw dict (also needed for download calls below):
 
 ```python
 analysis = bp.get_analysis(91182)
+print(analysis)
 ```
 
 ---
@@ -166,10 +160,11 @@ bp.delete_sample(75042)
 
 ## 4. Creating an analysis
 
-Create an analysis once you know the `workflow_id` (pipeline ID):
+Create an analysis once you know the `workflow_id` (pipeline ID). The call returns the new analysis ID:
 
 ```python
 analysis_id = bp.create_analysis(workflow_id=4, sample_id=75042)
+print(analysis_id)  # e.g. 91182
 ```
 
 With custom parameters:
@@ -206,11 +201,11 @@ bp.create_analysis(
 )
 ```
 
-With a ChIP-seq input control:
+With a ChIP-seq input control (replace `workflow_id` with your ChIP-seq pipeline ID from `bp.get_pipelines()`):
 
 ```python
 bp.create_analysis(
-    workflow_id=10,
+    workflow_id=YOUR_CHIP_SEQ_PIPELINE_ID,
     sample_id=75042,
     control_id=75050,
 )
@@ -219,6 +214,8 @@ bp.create_analysis(
 ---
 
 ## 5. Downloading results
+
+Replace `91182` with your actual analysis ID throughout this section.
 
 Download all files for an analysis into `./results/`:
 

--- a/docs/api-automation/python.md
+++ b/docs/api-automation/python.md
@@ -4,126 +4,127 @@ sidebar_position: 3
 
 # Python API
 
-**Updated for basepair version:** 2.0.0  
-Python bindings for Basepair’s API. An outline of the contents on this page:  
-1. Listing available data  
-2. Creating or deleting a sample  
-3. Create an analysis  
-4. Download result  
+**Updated for basepair version:** 3.x  
+Python bindings for Basepair's API. An outline of the contents on this page:
 
----  
+1. Connecting
+2. Listing available data
+3. Creating or deleting a sample
+4. Creating an analysis
+5. Downloading results
+6. Working with result files
 
-After starting a `python3` interactive session run:  
+---
+
+After installing the package (`pip install basepair`), start a `python3` session and connect:
 
 ```python
 import basepair
 import json
 
 bp = basepair.connect(json.load(open('/path/to/basepair.config.json')))
-```  
+```
 
-## 1. Listing available data  
-You can list various types of data available to you via the `bp.print_data()` command. By default it prints a human-readable table (critical fields only). Set `json=True` to view the full raw JSON.  
+---
 
-### 1.1 List genomes  
-Print the genomes table:  
+## 1. Connecting
+
+The `connect()` call reads your config file and authenticates against the API. The config file must contain an `api_v3` section — see [Setup](./setup) for how to obtain it.
+
+```python
+import basepair
+import json
+
+bp = basepair.connect(json.load(open('/path/to/basepair.config.json')))
+```
+
+You can also connect using environment variables without a file:
+
+```python
+import os
+import basepair
+
+os.environ['BP_USERNAME'] = 'user@example.com'
+os.environ['BP_API_KEY'] = 'YOUR_API_KEY'
+bp = basepair.connect()
+```
+
+---
+
+## 2. Listing available data
+
+### 2.1 List genomes
 
 ```python
 bp.print_data('genomes')
-```  
+```
 
-Typical output:  
+Typical output:
 
 ```
  id  name                      date_created
 ---- -----------------------   --------------------------
   1  hg19                      2018-04-18T14:58:15.865993
   2  mm10                      2018-04-18T15:05:39.770488
-  3  mm9                       2018-04-18T15:10:33.438603
+  3  mm9                       2018-04-18T15:10:33.388603
   …
-```  
+```
 
-Raw JSON:  
-
-```python
-bp.genomes
-```  
-
-```json
-[
-  {"date_created": "2018-04-18T14:58:15.865993", "id": 1, "name": "hg19",
-   "resource_uri": "/api/v1/genomes/1"},
-  {"date_created": "2018-04-18T15:05:39.770488", "id": 2, "name": "mm10",
-   "resource_uri": "/api/v1/genomes/2"},
-  …
-]
-```  
-
-### 1.2 List workflows  
-Pretty table:  
+Raw list:
 
 ```python
-bp.print_data('workflows')
-```  
+bp.get_genomes()
+```
 
-Raw JSON:  
+### 2.2 List pipelines
 
 ```python
-bp.get_workflows()
-```  
+bp.get_pipelines()
+```
 
-### 1.3 List samples  
-Pretty table:  
+### 2.3 List samples
 
 ```python
 bp.print_data('samples')
-```  
+```
 
-Raw JSON:  
-
-```python
-bp.get_samples()
-```  
-
-### 1.4 Get a sample  
+Raw list (optionally filtered):
 
 ```python
-sample = bp.get_sample(10000)
-```  
+bp.get_samples(filters={'projects': 8658})
+```
 
-### 1.5 List analyses  
-Pretty table:  
+### 2.4 Get a sample
+
+```python
+sample = bp.get_sample(75042)
+```
+
+### 2.5 List analyses
 
 ```python
 bp.print_data('analyses')
-```  
+```
 
-Raw JSON:  
-
-```python
-bp.get_analyses()
-```  
-
-#### 1.5.1 Analysis detail  
-Pretty table for analysis `10000`:  
+Raw list:
 
 ```python
-bp.print_data('analysis', uid=[10000])
-```  
+bp.get_analyses(filters={'projects': 8658})
+```
 
-Raw JSON:  
+Analysis detail:
 
 ```python
-bp.get_analysis(10000)
-```  
+analysis = bp.get_analysis(91182)
+```
 
----  
+---
 
-## 2. Creating or deleting a sample  
-A Basepair sample is handled through the `BpSample` class. You can either create a new sample or get information for an existing one.  
+## 3. Creating or deleting a sample
 
-### 2.1 Create a new sample  
-In this example we create **Sample1**—paired-end RNA-seq data on the Illumina platform using the **hg19** genome (project ID optional).  
+### 3.1 Create a new sample
+
+Create **Sample1** — paired-end RNA-seq data using the **hg19** genome:
 
 ```python
 data = {
@@ -133,41 +134,40 @@ data = {
     'platform': 'illumina',
     'filepaths1': [
         'Sample1.lane1.R1.fastq.gz',
-        'Sample1.lane2.R1.fastq.gz'],
+        'Sample1.lane2.R1.fastq.gz',
+    ],
     'filepaths2': [
         'Sample1.lane1.R2.fastq.gz',
-        'Sample1.lane2.R2.fastq.gz'],
-    # 'projects': '123',  # optional
+        'Sample1.lane2.R2.fastq.gz',
+    ],
+    # 'projects': 8658,  # optional
 }
 
-sample = bp.create_sample(data=data)
-```  
+sample_id = bp.create_sample(data=data)
+```
 
-Run `?BpSample` in Python for more fields.  
-
-### 2.2 Delete a sample  
+### 3.2 Delete a sample
 
 ```python
-bp.delete_sample(10000)   # returns <Response [204]> on success
-```  
+bp.delete_sample(75042)
+```
 
----  
+---
 
-## 3. Creating or deleting an analysis  
-*This section is still under construction.*  
+## 4. Creating an analysis
 
-Create an analysis (e.g., STAR mapping) once you know the `workflow_id`:  
+Create an analysis once you know the `workflow_id` (pipeline ID):
 
 ```python
-bp.create_analysis(workflow_id='4', sample_id='3206')
-```  
+analysis_id = bp.create_analysis(workflow_id=4, sample_id=75042)
+```
 
-Custom parameters example:  
+With custom parameters:
 
 ```python
 bp.create_analysis(
-    workflow_id='5',
-    sample_id='1',
+    workflow_id=5,
+    sample_id=75042,
     params={
         'node': {
             'annotate': {
@@ -177,75 +177,115 @@ bp.create_analysis(
         }
     }
 )
-```  
+```
 
-For pipelines needing >2 groups (e.g., DESeq, Cuffdiff):  
+For pipelines requiring multiple sample groups (e.g. DESeq2, Cuffdiff):
 
 ```python
 bp.create_analysis(
-    workflow_id='42',
+    workflow_id=42,
     sample_ids=[5014, 5016, 5017, 5018],
     params={
         'node': {
             'deseq': {
                 'group_ids': '5017,5018:5016:5014',
-                'group_names': 'group 1 name:group 2 name:group 3 name'
+                'group_names': 'group 1 name:group 2 name:group 3 name',
             }
         }
     }
 )
+```
 
+With a ChIP-seq input control:
+
+```python
 bp.create_analysis(
-    workflow_id='29',
-    sample_ids=[5014, 5016, 5017, 5018],
-    params={
-        'node': {
-            'cuffdiff': {
-                'group_ids': '5017,5018:5016:5014',
-                'group_names': 'group 1 name:group 2 name:group 3 name'
-            }
-        }
-    }
+    workflow_id=10,
+    sample_id=75042,
+    control_id=75050,
 )
-```  
+```
 
----  
+---
 
-## 4. Download results  
-You can download files from one or more analyses.  
+## 5. Downloading results
 
-### 4.1 Example 1  
-*Downloads analysis 10000, excluding files tagged “bam”, into `./test/`:*  
+Download all files for an analysis into `./results/`:
+
+```python
+analysis = bp.get_analysis(91182)
+bp.download_analysis(
+    uid=91182,
+    analysis=analysis,
+    outdir='./results/',
+)
+```
+
+Download only files tagged **fastqc**, excluding all others:
 
 ```python
 bp.download_analysis(
-    10000,
-    tags=[['bam']],
-    tagkind='diff',
-    outdir='./test/')
-```  
-
-### 4.2 Example 2  
-*Downloads only files tagged “fastqc” from analysis 10000 into `./test/`:*  
-
-```python
-bp.download_analysis(
-    10000,
+    uid=91182,
+    analysis=analysis,
     tags=[['fastqc']],
     tagkind='subset',
-    outdir='./test/')
-```  
+    outdir='./test/',
+)
+```
 
-### 4.3 Example 3  
-*Downloads files tagged either (“rnaseq_metrics” & “json”) **or** (“fastqc” & “zip”) from analysis 10000 into `./test/`:*  
+Download files tagged **bam** (exact match), excluding everything else:
 
 ```python
 bp.download_analysis(
-    10000,
+    uid=91182,
+    analysis=analysis,
+    tags=[['bam']],
+    tagkind='diff',
+    outdir='./test/',
+)
+```
+
+Download files matching either (`rnaseq_metrics` + `json`) **or** (`fastqc` + `zip`):
+
+```python
+bp.download_analysis(
+    uid=91182,
+    analysis=analysis,
     tags=[['rnaseq_metrics', 'json'], ['fastqc', 'zip']],
     tagkind='exact',
-    outdir='./test/')
-```  
+    outdir='./test/',
+)
+```
 
+**Tag filter modes:**
 
+| Mode | Behaviour |
+|------|-----------|
+| `exact` | Only files whose tag set exactly matches the provided tags |
+| `subset` | Any file that has at least one of the provided tags |
+| `diff` | Exclude files that have the provided tag |
 
+---
+
+## 6. Working with result files
+
+In API v3, file objects return a `uri` field containing the full S3 URI. Use this instead of the older `path` field:
+
+```python
+analysis = bp.get_analysis(91182)
+for f in analysis['files']:
+    print(f['name'], f['uri'])
+    # e.g. sample.bam  s3://basepair-results/data/91182/sample.bam
+```
+
+If you need the bare S3 key (without the `s3://bucket/` prefix):
+
+```python
+from basepair.modules.storage.drivers.aws_s3 import Driver as S3Driver
+
+for f in analysis['files']:
+    s3_key = S3Driver.get_path_from_uri(f['uri'])
+    print(s3_key)   # e.g. data/91182/sample.bam
+```
+
+> **Note:** If you are upgrading from v2, replace any `file['path']` references with `file['uri']`. See the [migration guide](./migration) for the full list of changes.

--- a/docs/api-automation/python.md
+++ b/docs/api-automation/python.md
@@ -38,6 +38,16 @@ import json
 bp = basepair.connect(json.load(open('/path/to/basepair.config.json')))
 ```
 
+Starting with package 3.x, **v3 is the default**. To explicitly select a version, pass the `version` argument:
+
+```python
+# Explicit v3 (same as default)
+bp = basepair.connect(json.load(open('/path/to/basepair.config.json')), version='v3')
+
+# Explicit v2 (requires an "api" section in your config)
+bp = basepair.connect(json.load(open('/path/to/basepair.config.json')), version='v2')
+```
+
 You can also connect using environment variables without a file:
 
 ```python
@@ -289,3 +299,60 @@ for f in analysis['files']:
 ```
 
 > **Note:** If you are upgrading from v2, replace any `file['path']` references with `file['uri']`. See the [migration guide](./migration) for the full list of changes.
+
+---
+
+## 7. Using individual module classes directly
+
+The package exposes lower-level classes (`Analysis`, `Sample`, `Upload`, `Pipeline`, `Module`, etc.) for operations not available on the `BpApi` wrapper — such as bulk actions or custom filters.
+
+These classes take the raw API config dict as their first argument. With a v3 config file, that dict lives under the `api_v3` key:
+
+```python
+import json
+from basepair import Analysis, Sample
+
+config = json.load(open('/path/to/basepair.config.json'))
+
+# v3 config: use config.get('api_v3')
+analyses = Analysis(config.get('api_v3')).list_all_full(
+    filters={
+        'id__in': [91182, 91183],
+        'status__in': ['completed', 'failed'],
+        'order_by': '-last_updated',
+    }
+)
+
+# Bulk start analyses
+Analysis(config.get('api_v3')).bulk_start({'analyses': [...]})
+
+# Bulk import samples
+Sample(config.get('api_v3')).bulk_import({'samples': [], 'project_id': 8658})
+```
+
+> **Important:** Always match the config key to the API version you are targeting — `api_v3` for v3, `api` for v2. Passing the wrong key results in a `None` config and a connection error.
+
+If you are already using `basepair.connect()`, you can extract the resolved config from the `bp` object instead of reading the file again:
+
+```python
+bp = basepair.connect(json.load(open('/path/to/basepair.config.json')))
+
+# bp.conf['api'] always holds the resolved config for whichever version was connected
+Analysis(bp.conf.get('api')).list_all_full(filters={...})
+```
+
+---
+
+## 8. Error responses
+
+In v3, API errors return structured JSON with an `errors` array:
+
+```json
+{
+  "errors": [
+    {"detail": "No analysis found with id 99999."}
+  ]
+}
+```
+
+In v2, error messages were unstructured plain text. If you have code that parses error strings, update it to handle the v3 format or use the `BpApi` wrapper which normalises errors across versions.

--- a/docs/api-automation/setup.md
+++ b/docs/api-automation/setup.md
@@ -37,7 +37,7 @@ basepair -h
 You need a configuration file to connect to Basepair’s API. To obtain it:
 
 1. Go to your dashboard: [app.basepairtech.com](https://app.basepairtech.com)  
-2. Click your profile name (top-right).  
+2. Click the profile icon (top-right).  
 3. Click **Profile**.  
 4. Click **Download API config file** (upper-right).
 

--- a/docs/api-automation/setup.md
+++ b/docs/api-automation/setup.md
@@ -16,7 +16,7 @@ Contents:
 
 ### Requirements
 
-* **Python 3** (Python 2 is no longer supported)
+* **Python 3.8+** (Python 2 is no longer supported)
 
 ### Install the package
 
@@ -45,22 +45,22 @@ A downloaded file looks like:
 
 ```json
 {
-  "api": {
+  "api_v3": {
     "cli": true,
     "host": "app.basepairtech.com",
-    "prefix": "/api/v2/",
+    "prefix": "/api/v3/",
     "ssl": true,
     "username": "user@basepairtech.com",
-    "key": ""
+    "key": "YOUR_API_KEY"
   }
 }
 ```
 
-`key` is your personal access token.
+`key` is your personal access token. The `api_v3` section targets the current API (v3). If your downloaded file still shows an `api` section with `/api/v2/`, see the [migration guide](./migration) to update it.
 
 To make this file available to your API calls, choose one of the following:
 
-**Option 1 – environment variable**
+**Option 1 – environment variable (recommended)**
 
 ```bash
 export BP_CONFIG_FILE=/path/to/basepair.config.json
@@ -70,6 +70,13 @@ export BP_CONFIG_FILE=/path/to/basepair.config.json
 
 ```bash
 basepair -c /path/to/basepair.config.json
+```
+
+**Option 3 – environment variables only (no file needed)**
+
+```bash
+export BP_USERNAME=user@basepairtech.com
+export BP_API_KEY=YOUR_API_KEY
 ```
 
 You can now use Basepair’s genomics tools from the CLI or the Python API.  

--- a/docs/api-automation/setup.md
+++ b/docs/api-automation/setup.md
@@ -58,6 +58,36 @@ A downloaded file looks like:
 
 `key` is your personal access token. The `api_v3` section targets the current API (v3). If your downloaded file still shows an `api` section with `/api/v2/`, see the [migration guide](./migration) to update it.
 
+### Config keys and API versions
+
+The config section key determines which API version the SDK uses:
+
+| Config key | `prefix` | API version |
+|------------|----------|-------------|
+| `api_v3`   | `/api/v3/` | v3 (default since package 3.x) |
+| `api`      | `/api/v2/` | v2 (legacy) |
+
+You can keep both sections in the same file if you need to switch versions:
+
+```json
+{
+  "api_v3": {
+    "host": "app.basepairtech.com",
+    "prefix": "/api/v3/",
+    "ssl": true,
+    "username": "user@example.com",
+    "key": "YOUR_V3_KEY"
+  },
+  "api": {
+    "host": "app.basepairtech.com",
+    "prefix": "/api/v2/",
+    "ssl": true,
+    "username": "user@example.com",
+    "key": "YOUR_V2_KEY"
+  }
+}
+```
+
 To make this file available to your API calls, choose one of the following:
 
 **Option 1 – environment variable (recommended)**


### PR DESCRIPTION
## Summary

- **setup.md**: Updates config file format to show `api_v3` section with `/api/v3/` prefix (replaces outdated `api`/`/api/v2/`); adds environment variable auth option (`BP_USERNAME` + `BP_API_KEY`)
- **cli.md**: Full rewrite for v3 subcommand structure (`basepair <resource> <action>`); adds `reanalyze`, `terminate`, pipeline/module management, `file download`, `--json` flag, and tag filter mode table
- **python.md**: Updates version string, adds `file['uri']` usage (replaces `file['path']`), expands analysis and download sections with current method signatures
- **automation.md**: Fixes commands from pre-v2 syntax (`basepair create sample`) to v3 subcommand style
- **migration.md** *(new)*: Covers all v2→v3 breaking changes with before/after examples and a migration checklist

## Related

WEBAPP-1152 — tied to basepair-python PR #190 (v3 migration), bioinfo PR #440, worker PRs #83/#84

## Test plan

- [ ] Verify Docusaurus build renders all five pages without errors
- [ ] Check sidebar ordering (setup=1, cli=2, python=3, automation=4, migration=5)
- [ ] Confirm code blocks copy correctly in the rendered docs
- [ ] Spot-check that CLI examples match current `basepair -h` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)